### PR TITLE
Actions and events should use the moleculer 'version.serviceName.actionName' format automatically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ version = "0.4.1"
 [dependencies]
 # async
 async-trait = "0.1"
-tokio = {version = "1.2", features = ["macros", "rt-multi-thread", "sync"]}
+tokio = {version = "1.47", features = ["macros", "rt-multi-thread", "sync"]}
 
 
 # actor framework
 act-zero = {version = "0.4", features = ["default-tokio"]}
 
 # nats
-async-nats = "0.37"
+async-nats = "0.42"
 futures = "0.3"
 
 # error handling
@@ -41,18 +41,18 @@ rand = "0.8"
 # node information
 get_if_addrs = "0.5.3"
 hostname = "0.4"
-sysinfo = "0.31"
+sysinfo = "0.37"
 
 # utils
 ctrlc = {version = "3.0", features = ["termination"]}
 derive_builder = "0.20"
 maplit = "1.0"
-strum = {version = "0.26", features = ["derive"]}
-uuid = {version = "1.10", features = ["serde", "v4"]}
-bytes = "1.7"
+strum = {version = "0.27", features = ["derive"]}
+uuid = {version = "1.18", features = ["serde", "v4"]}
+bytes = "1.10"
 
 [build-dependencies]
-built = "0.7"
+built = "0.8"
 
 # for examples
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 name = "moleculer"
 readme = "README.md"
 repository = "https://github.com/primcloud/moleculer-rs"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 # async

--- a/src/channels/heartbeat.rs
+++ b/src/channels/heartbeat.rs
@@ -85,7 +85,7 @@ impl Heartbeat {
             heartbeat_interval: config.heartbeat_interval,
             timer: Timer::default(),
             system: System::new_with_specifics(
-                RefreshKind::new().with_cpu(CpuRefreshKind::everything()),
+                RefreshKind::nothing().with_cpu(CpuRefreshKind::everything()),
             ),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -294,7 +294,7 @@ pub(crate) enum DeserializeError {
     Json(serde_json::error::Error),
 }
 
-fn mol(config: &Config) -> Cow<str> {
+fn mol(config: &Config) -> Cow<'_, str> {
     if config.namespace.is_empty() {
         Cow::Borrowed("MOL")
     } else {

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -36,7 +36,7 @@ where
         self.queue.len()
     }
 
-    pub(crate) fn iter(&self) -> std::collections::vec_deque::Iter<T> {
+    pub(crate) fn iter(&self) -> std::collections::vec_deque::Iter<'_, T> {
         self.queue.iter()
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -152,7 +152,7 @@ impl ActionBuilder {
 #[serde(rename_all = "camelCase")]
 pub struct Service {
     name: String,
-    version: Option<i32>,
+    version: Option<String>,
 
     #[serde(default)]
     #[serde(skip_deserializing)]
@@ -172,18 +172,26 @@ impl Service {
         }
     }
 
-    pub fn set_version(mut self, version: i32) -> Self {
+    pub fn set_version(mut self, version: String) -> Self {
         self.version = Some(version);
         self
     }
 
+    fn _make_key(&self, suffix: &str) -> String {
+        if let Some(ref version) = self.version {
+            format!("{}.{}.{}", version, self.name, suffix)
+        } else {
+            format!("{}.{}", self.name, suffix)
+        }
+    }
+
     pub fn add_action(mut self, action: Action) -> Self {
-        self.actions.insert(action.name.clone(), action);
+        self.actions.insert(self._make_key(&action.name), action);
         self
     }
 
     pub fn add_event(mut self, event: Event) -> Self {
-        self.events.insert(event.name.clone(), event);
+        self.events.insert(self._make_key(&event.name), event);
         self
     }
 }


### PR DESCRIPTION
Hello,

I applied small change to address the issue here: https://github.com/avencera/moleculer-rs/issues/28